### PR TITLE
Refactor: [필수 LV1 - 메서드명 수정 및 상태코드 추가, 전체 일정 조회 동적 쿼리조건 변경]

### DIFF
--- a/src/main/java/spring/basic/scheduler/required/controller/SchedulerController.java
+++ b/src/main/java/spring/basic/scheduler/required/controller/SchedulerController.java
@@ -21,16 +21,17 @@ public class SchedulerController {
 
     @PostMapping
     public ResponseEntity<SchedulerCommonResponseDto> addContent(@RequestBody SchedulerCreateRequestDto createRequestDto) {
-        return new ResponseEntity<>(schedulerService.saveContent(createRequestDto), HttpStatus.CREATED);
+        return new ResponseEntity<>(schedulerService.saveSchedule(createRequestDto), HttpStatus.CREATED);
     }
 
     @GetMapping
-    public List<SchedulerFindResponseDto> schedules(SchedulerSearchCond searchCond) {
+    public List<SchedulerFindResponseDto> findSchedules(SchedulerSearchCond searchCond) {
         return schedulerService.findAllSchedules(searchCond);
     }
 
     @GetMapping("/{id}")
-    public SchedulerFindResponseDto schedule(@PathVariable Long id) {
-        return schedulerService.findScheduleById(id);
+    public ResponseEntity<SchedulerFindResponseDto> findSchedule(@PathVariable Long id) {
+        return new ResponseEntity<>(schedulerService.findScheduleById(id), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/spring/basic/scheduler/required/repository/SchedulerRepository.java
+++ b/src/main/java/spring/basic/scheduler/required/repository/SchedulerRepository.java
@@ -13,4 +13,5 @@ public interface SchedulerRepository {
     List<SchedulerFindResponseDto> findAllSchedules(SchedulerSearchCond searchCond);
 
     Optional<SchedulerFindResponseDto> findScheduleById(Long id);
+
 }

--- a/src/main/java/spring/basic/scheduler/required/service/SchedulerService.java
+++ b/src/main/java/spring/basic/scheduler/required/service/SchedulerService.java
@@ -1,14 +1,14 @@
 package spring.basic.scheduler.required.service;
 
-import spring.basic.scheduler.required.model.dto.SchedulerCreateRequestDto;
 import spring.basic.scheduler.required.model.dto.SchedulerCommonResponseDto;
+import spring.basic.scheduler.required.model.dto.SchedulerCreateRequestDto;
 import spring.basic.scheduler.required.model.dto.SchedulerFindResponseDto;
 import spring.basic.scheduler.required.model.dto.SchedulerSearchCond;
 
 import java.util.List;
 
 public interface SchedulerService {
-    SchedulerCommonResponseDto saveContent(SchedulerCreateRequestDto CreateRequestDto);
+    SchedulerCommonResponseDto saveSchedule(SchedulerCreateRequestDto CreateRequestDto);
 
     List<SchedulerFindResponseDto> findAllSchedules(SchedulerSearchCond searchCond);
 

--- a/src/main/java/spring/basic/scheduler/required/service/SchedulerServiceImpl.java
+++ b/src/main/java/spring/basic/scheduler/required/service/SchedulerServiceImpl.java
@@ -23,7 +23,7 @@ public class SchedulerServiceImpl implements SchedulerService {
 
     @Override
     @Transactional
-    public SchedulerCommonResponseDto saveContent(SchedulerCreateRequestDto createRequestDto) {
+    public SchedulerCommonResponseDto saveSchedule(SchedulerCreateRequestDto createRequestDto) {
 
         Schedule schedule = Schedule.builder()
                 .content(createRequestDto.getContent())
@@ -53,4 +53,6 @@ public class SchedulerServiceImpl implements SchedulerService {
 
         return optionalFindSchedule.get();
     }
+
+
 }


### PR DESCRIPTION
1. 생성 API 관련 메서드들의 이름을 필드인 content보다 더 명확한 entity인 schedule로 변경
2. 조회 API controller 메서드에 find 키워드를 추가하여 더 명확하게 구분
3. 조회 API에 빠진 응답상태코드 추가
4. 전체 일정 조회의 동적 쿼리의 날짜 검색 조건이 정상적으로 동작하지 않아서 변경